### PR TITLE
update to ecology letters

### DIFF
--- a/ecology-letters.csl
+++ b/ecology-letters.csl
@@ -184,7 +184,7 @@
           <text macro="event"/>
           <text macro="publisher"/>
           <group>
-            <label variable="page" form="short" suffix=" "/>
+            <label variable="page" form="short" suffix="."/>
             <text variable="page"/>
           </group>
         </group>
@@ -209,9 +209,6 @@
       <key macro="issued" sort="ascending"/>
     </sort>
     <layout>
-      <group display="block">
-        <text variable="citation-number" suffix="."/>
-      </group>
       <group suffix=".">
         <text macro="author" suffix="."/>
         <text macro="issued" prefix=" (" suffix="). "/>


### PR DESCRIPTION
Ecology letters citations are not numbered (though a total number of citations does need to be provided), and each citation in the bibliography ends with a period. See section "V. Reference list" here:
http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291461-0248/homepage/ForAuthors.html

removed "citation-number" group from bibliography. Added suffix="." to "page" group of "locators" macro.  
Note: this is my first time editing CLS, so double check.
